### PR TITLE
feature/show-spinner-when-loading-organization-issues

### DIFF
--- a/components/IssueTracker.js
+++ b/components/IssueTracker.js
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import TimelineChart from '~/components/TimelineChart'
 import StatsIndicator from '~/components/StatsIndicator'
 import Pill from '~/components/Pill'
+import Loader from 'icons/Loader'
 import Url from '~/icons/Url'
 import Info from 'icons/Info'
 
@@ -9,6 +10,7 @@ const IssueTracker = ({
   embed = false,
   repoName,
   issueCounts,
+  loadingIssueCounts = false,
   latestOpenIssueCount,
   openIssueCountComparison,
   latestClosedIssueCount
@@ -26,6 +28,51 @@ const IssueTracker = ({
   ] 
   
   const [issueType, setIssueType] = useState(options[0])
+
+  const renderTimelineChart = () => {
+    if (issueCounts.length > 0) {
+      return (
+        <>
+          <div className="w-full pb-3 sm:pb-0 sm:pr-3">
+            <TimelineChart
+              id="issueCountsChart"
+              uPlot={uPlot}
+              data={issueCounts}
+              dateKey="inserted_at"
+              valueKey={issueType.key}
+              xLabel="Issue count"
+              showBaselineToggle={true}
+            />
+          </div>
+          {!embed && (
+            <div className="sm:px-10 w-full mt-10 flex flex-col">
+              <p className="text-white">Daily statistics</p>
+              <div className="mt-5 grid grid-cols-12 gap-x-5">
+                <div className="col-span-6 sm:col-span-5 xl:col-span-4">
+                  <p className="text-gray-400">Open issues</p>
+                  <div id="numbers" className="flex items-center mt-2">
+                    <p className="text-white text-3xl mr-2">{latestOpenIssueCount}</p>
+                    <StatsIndicator countDiff={openIssueCountComparison} />
+                  </div>
+                </div>
+                <div className="col-span-6 sm:col-span-5 xl:col-span-4">
+                  <p className="text-gray-400">Total closed issues</p>
+                  <p className="mt-2 text-white text-3xl">{latestClosedIssueCount}</p>
+                </div>
+              </div>
+            </div>
+          )}
+        </>
+      )
+    } else {
+      return (
+        <div className="px-5 sm:px-10 text-gray-400 w-full flex-1 flex flex-col items-center justify-center text-center">
+          <Info />
+          <span className="mt-5">Issues under {repoName} are not being tracked at the moment.</span>
+        </div>
+      )
+    }
+  }
 
   return (
     <>
@@ -52,45 +99,15 @@ const IssueTracker = ({
         </p>
       </div>
       <div className="flex-1 flex flex-col items-start">
-        {issueCounts.length > 0
+        {loadingIssueCounts
           ? (
-            <>
-              <div className="w-full pb-3 sm:pb-0 sm:pr-3">
-                <TimelineChart
-                  id="issueCountsChart"
-                  uPlot={uPlot}
-                  data={issueCounts}
-                  dateKey="inserted_at"
-                  valueKey={issueType.key}
-                  xLabel="Issue count"
-                  showBaselineToggle={true}
-                />
-              </div>
-              {!embed && (
-                <div className="sm:px-10 w-full mt-10 flex flex-col">
-                  <p className="text-white">Daily statistics</p>
-                  <div className="mt-5 grid grid-cols-12 gap-x-5">
-                    <div className="col-span-6 sm:col-span-5 xl:col-span-4">
-                      <p className="text-gray-400">Open issues</p>
-                      <div id="numbers" className="flex items-center mt-2">
-                        <p className="text-white text-3xl mr-2">{latestOpenIssueCount}</p>
-                        <StatsIndicator countDiff={openIssueCountComparison} />
-                      </div>
-                    </div>
-                    <div className="col-span-6 sm:col-span-5 xl:col-span-4">
-                      <p className="text-gray-400">Total closed issues</p>
-                      <p className="mt-2 text-white text-3xl">{latestClosedIssueCount}</p>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </>
+            <div className="py-24 lg:py-32 text-white w-ful flex flex-col items-center justify-center">
+              <Loader />
+              <p className="text-xs mt-3 leading-5 text-center">Retrieving issues from {repoName}</p>
+            </div>
           )
           : (
-            <div className="px-5 sm:px-10 text-gray-400 w-full flex-1 flex flex-col items-center justify-center text-center">
-              <Info />
-              <span className="mt-5">Issues under {repoName} are not being tracked at the moment.</span>
-            </div>
+            <>{renderTimelineChart()}</>
           )
         }
       </div>

--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -63,9 +63,7 @@ const StarHistory = ({
               </div>
             )
             : (
-              <>
-                {renderTimelineChart()}
-              </>
+              <>{renderTimelineChart()}</>
             )
           }
         </div>

--- a/pages/[org]/[repo]/index.js
+++ b/pages/[org]/[repo]/index.js
@@ -128,39 +128,45 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
           </>
         )
         : (
-          <div className="p-10">
-            {!router.query.type && (
-              <div className="h-screen w-screen flex flex-col items-center justify-center">
-                <p className="mb-2 text-white">Specify what type of charts you would like to embed as such:</p>
-                <p className="text-white mb-5">{window.location.href}&type=[chartType]</p>
-                <p className="text-gray-400">
-                  Available chart types:
-                  <span className="font-mono ml-2 border-r mr-2 pr-2">stars</span>
-                  <span className="font-mono">issues</span>
-                </p>
-              </div>
-            )}
-            {router.query.type === 'stars' && (
-              <StarHistory
-                embed={true}
-                repoName={repoName}
-                lastUpdated={lastUpdated}
-                starHistory={starHistory}
-                loadingStarHistory={loadingStarHistory}
-              />
-            )}
-            {router.query.type === 'issues' && (
-              <IssueTracker
-                embed={true}
-                repoName={repoName}
-                issueCounts={issueCounts}
-                loadingIssueCounts={loadingIssueCounts}
-                latestOpenIssueCount={retrieveLatestOpenIssueCount()}
-                openIssueCountComparison={deriveOpenIssueCountComparison()}
-                latestClosedIssueCount={retrieveLatestCloseIssueCount()}
-              />
-            )}
-          </div>
+          <>
+            {!router.query.type
+              ? (
+                <div className="h-screen w-screen flex flex-col items-center justify-center">
+                  <p className="mb-2 text-white">Specify what type of charts you would like to embed as such:</p>
+                  <p className="text-white mb-5">{window.location.href}&type=[chartType]</p>
+                  <p className="text-gray-400">
+                    Available chart types:
+                    <span className="font-mono ml-2 border-r mr-2 pr-2">stars</span>
+                    <span className="font-mono">issues</span>
+                  </p>
+                </div>
+              )
+              : (
+                <div className="p-10">
+                  {router.query.type === 'stars' && (
+                    <StarHistory
+                      embed={true}
+                      repoName={repoName}
+                      lastUpdated={lastUpdated}
+                      starHistory={starHistory}
+                      loadingStarHistory={loadingStarHistory}
+                    />
+                  )}
+                  {router.query.type === 'issues' && (
+                    <IssueTracker
+                      embed={true}
+                      repoName={repoName}
+                      issueCounts={issueCounts}
+                      loadingIssueCounts={loadingIssueCounts}
+                      latestOpenIssueCount={retrieveLatestOpenIssueCount()}
+                      openIssueCountComparison={deriveOpenIssueCountComparison()}
+                      latestClosedIssueCount={retrieveLatestCloseIssueCount()}
+                    />
+                  )}
+                </div>
+              )
+            }
+          </>
         )
       }
     </>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/repository.surf/issues/21

Shows a spinner on the organization overview page when loading issues
Also added a spinner on issue tracker when loading issues too
This will resolve the flashing of issues not being tracked message for both contexts