### PR TITLE
refactor: reverse star retrieval order

### DIFF
--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -50,7 +50,7 @@ const StarHistory = ({
             </div>
           )}
         </div>
-        <p className="mt-2 text-base text-gray-400">This is a timeline of how the stars of {repoName} has grown till today.</p>
+        <p className="mt-2 text-base text-gray-400">This is a timeline of how the star count of {repoName} has grown till today.</p>
         {lastUpdated && <p className="mt-3 text-gray-400 text-xs">Last updated on: {new Date(lastUpdated).toDateString()}</p>}
       </div>
       <div className="flex-1 flex flex-col items-start">

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -82,7 +82,7 @@ const getGithubStarGql = async ({organization, repoName, cursor, githubAccessTok
   const query = `
     query fetchGithubStars($organization: String!, $repoName: String!, $cursor: String) {
         repository(owner: $organization, name: $repoName) {
-            stargazers(last: 100, before: $cursor) {
+            stargazers(first: 100, after: $cursor) {
                 totalCount
                 edges{
                     starredAt
@@ -131,12 +131,11 @@ export const retrieveStarHistory = async(organization, repoName, githubAccessTok
   // let callCount = 1
 
   while (stargazers.length > 0) {
-    // Get the cursor of the oldest event.
-    cursor = stargazers[0].cursor
+    // Get the cursor of the newest event.
+    cursor = stargazers[stargazers.length - 1].cursor
 
-    // Use reverse() to get newest first.
-    // And use slice(0, 10) to get the date only (and not time)
-    starredAtArray.push(stargazers.reverse().map(x => x.starredAt.slice(0, 10)))
+    // Use slice(0, 10) to get the date only (and not time).
+    starredAtArray.push(stargazers.map(x => x.starredAt.slice(0, 10)))
     // Retrieve the starring events before the cursor.
     result = await getGithubStarGql({organization, repoName, cursor, githubAccessToken})
     stargazers = result.edges
@@ -151,9 +150,7 @@ export const retrieveStarHistory = async(organization, repoName, githubAccessTok
     // }
   }
 
-  // Use reverse() again to get oldest first.
-  starredAtArray = starredAtArray.flat().reverse()
-
+  starredAtArray = starredAtArray.flat()
   let accumulativeCount = 0
   const starCountDateMap = {}
 
@@ -247,7 +244,7 @@ export const getRepositoryStarHistory = async(supabase, starsTable, organization
   if (error) {
     console.log(error)
   } else if (data) {
-    if (data.length == 0) {
+    if (true) {
       const starHistory = await renewStarHistory(supabase, starsTable, organization, repoName, githubAccessToken)
       return {starHistory, historyUpdateTime: new Date().getTime()}
     } else {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -244,7 +244,7 @@ export const getRepositoryStarHistory = async(supabase, starsTable, organization
   if (error) {
     console.log(error)
   } else if (data) {
-    if (true) {
+    if (data.length == 0) {
       const starHistory = await renewStarHistory(supabase, starsTable, organization, repoName, githubAccessToken)
       return {starHistory, historyUpdateTime: new Date().getTime()}
     } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Retrieve stargazers from oldest -> newest instead of newest -> oldest. This way, it'll be easier to keep track of the oldest stargazer that we've seen so far. Then, the next time we call GitHub API, we can use that info so we won't have to retrieve all the stargazers again (only retrieve the most recent ones).

This PR will be the first one out of several for #23, #13, and #11.