### PR TITLE
feature: better handle star retrieval subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# vscode
+.vscode

--- a/lib/RepoStarHistoryRetriever.js
+++ b/lib/RepoStarHistoryRetriever.js
@@ -1,0 +1,50 @@
+import { getRepositoryStarHistory, uuid } from 'lib/helpers'
+
+export default class RepoStarHistoryRetriever {
+  constructor(supabase, starsTable, organization, repoName, githubAccessToken) {
+    this.supabase = supabase
+    this.starsTable = starsTable
+    this.organization = organization
+    this.repoName = repoName
+    this.githubAccessToken = githubAccessToken
+    this.starHistory = []
+    this.historyUpdateTime = null
+    this.isLoading = true
+    this.subscriptions = new Map()
+
+    this._loadStarHistory()
+  }
+
+  async _loadStarHistory(){
+    const {starHistory, historyUpdateTime} =
+      await getRepositoryStarHistory(this.supabase, this.starsTable, this.organization, this.repoName, this.githubAccessToken)
+    this.starHistory = starHistory
+    this.historyUpdateTime = historyUpdateTime
+    this.isLoading = false
+    this._notifyAllSubscribers()
+  }
+
+  _notifyAllSubscribers() {
+    this.subscriptions.forEach((x) => 
+      x.callback(this.starHistory, this.historyUpdateTime, this.isLoading)
+    )
+  }
+
+  onLoaded(callback){
+    try {
+      const id = uuid()
+      let self = this
+      const subscription = {
+        callback,
+        unsubscribe: () => {
+          self.subscriptions.delete(id)
+        },
+      }
+      this.subscriptions.set(id, subscription)
+      return { subscription, error: null }
+    } catch (error) {
+      console.log(error)
+      return { subscription: null, error }
+    }
+  }
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,13 @@
 import { fetchAllAndWait, fetchAndWait, postAndWait } from 'lib/fetchWrapper'
 
+export function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
 export const updateUserPreferences = (organization, newPreferences) => {
   const userPreferences = JSON.parse(localStorage.getItem(`repoSurf_${organization}`))
   const updatedPreferences = {

--- a/pages/[org]/[repo]/index.js
+++ b/pages/[org]/[repo]/index.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
-import { getRepositoryStarHistory } from 'lib/helpers'
+import RepoStarHistoryRetriever from 'lib/RepoStarHistoryRetriever'
 import IssueTracker from '~/components/IssueTracker'
 import StarHistory from '~/components/StarHistory'
 import ExternalLink from '~/icons/ExternalLink'
@@ -20,6 +20,10 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
   const [starHistory, setStarHistory] = useState([])
   const [loadingStarHistory, setLoadingStarHistory] = useState(false)
 
+  // An object of star history retrievers.
+  // Example: {'supabase/supabase': RepoStarHistoryRetriever1, 'supabase/realtime': RepoStarHistoryRetriever2}
+  const [starHistoryRetrievers, setStarHistoryRetrievers] = useState({})
+
   useEffect(() => {
     (async function retrieveRepositoryIssueCounts() {
       setLoadingIssueCounts(true)
@@ -38,15 +42,34 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
   }, [repoName])
 
   useEffect(() => {
-    (async function retrieveRepositoryStarHistory() {
-      setLoadingStarHistory(true)
-      setLastUpdated(null)
+    // First, check if a corresponding star history retriever exists.
+    // If not, create a new one.
+    const starHistoryKey = `${organization}/${repoName}`
+    let starHistoryRetriever
+    if (starHistoryKey in starHistoryRetrievers) {
+      starHistoryRetriever = starHistoryRetrievers[starHistoryKey]
+    } else {
+      starHistoryRetriever = new RepoStarHistoryRetriever(supabase, starsTable, organization, repoName, githubAccessToken)
+      const newRetrievers = Object.assign({}, starHistoryRetrievers)
+      newRetrievers[starHistoryKey] = starHistoryRetriever
+      setStarHistoryRetrievers(newRetrievers)
+    }
 
-      const {starHistory, historyUpdateTime} = await getRepositoryStarHistory(supabase, starsTable, organization, repoName, githubAccessToken)
+    // In case the star history is already retrieved, load it on on this component.
+    setStarHistory(starHistoryRetriever.starHistory)
+    setLastUpdated(starHistoryRetriever.historyUpdateTime)
+    setLoadingStarHistory(starHistoryRetriever.isLoading)
+
+    // Then, subscribe to any change in the star history retriever.
+    const { subscription } = starHistoryRetriever.onLoaded((starHistory, historyUpdateTime, isLoading) => {
       setStarHistory(starHistory)
       setLastUpdated(historyUpdateTime)
-      setLoadingStarHistory(false)
-    })()
+      setLoadingStarHistory(isLoading)
+    })
+    
+    return () => {
+      subscription.unsubscribe()
+    }
   }, [repoName])
 
   const retrieveLatestOpenIssueCount = () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

(This PR is based on #27)

This fixes #13, and it's also a good stepping stone for #23 and #11.

With this PR, we're handling star retrieval subscriptions in a much better way.

Basically, whenever we want to retrieve a star history, we create a RepoStarHistoryRetrieval object, which handles calling GitHub API, as well as subscribing to / unsubscribing from any updates from the API calls.

This way, when a user clicks one repo and clicks another, the first RepoStarHistoryRetrieval object will keep retrieving the history, but when it's loaded, nothing happens on the UI as no one is subscribed to it at that point. We can change this particular behaviour if loading in the background becomes too much.

With this feature, as a bonus, switching between already-loaded repos becomes instantaneous (because we can keep the RepoStarHistoryRetieval objects on the client):

https://user-images.githubusercontent.com/1811651/103325384-7cd94000-4a00-11eb-9079-27a3d1f357a4.mov