### PR TITLE
feature: incremental star retrival

### DIFF
--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -48,7 +48,7 @@ const StarHistory = ({
                 </div>
               </div>
             </div>
-            {!loadingStarHistory && starHistory.length > 0 && (
+            {!loadingStarHistory && lastUpdated && starHistory.length > 0 && (
               <div className="flex items-center">
                 <Star />
                 <span className="ml-2 text-white">{starHistory[starHistory.length - 1].starNumber}</span>
@@ -57,9 +57,9 @@ const StarHistory = ({
           </div>
           <p className="mt-2 text-base text-gray-400">This is a timeline of how the star count of {repoName} has grown till today.</p>
           {!loadingStarHistory && (
-            <p className="mt-3 text-gray-400 text-xs">
-              {lastUpdated ? 
-                <>Last updated on: {new Date(lastUpdated).toDateString()}</>
+            <div className="mt-3 text-gray-400 text-xs">
+              {lastUpdated
+                ? <span>Last updated on: {new Date(lastUpdated).toDateString()}</span>
                 : starHistory.length > 0 && (
                   <div className="flex item-center">
                     <Loader size={18} additionalClassName="inline"/>
@@ -71,7 +71,7 @@ const StarHistory = ({
                   </div>
                 )
               }
-            </p>
+            </div>
           )}
         </div>
       )}

--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -8,7 +8,8 @@ const StarHistory = ({
   repoName,
   lastUpdated,
   starHistory,
-  loadingStarHistory
+  loadingStarHistory,
+  totalStarCount
 }) => {
 
   const renderTimelineChart = () => {
@@ -46,12 +47,26 @@ const StarHistory = ({
           {!loadingStarHistory && starHistory.length > 0 && (
             <div className="flex items-center">
               <Star />
-              <span className="ml-2 text-white">{starHistory[starHistory.length - 1].starNumber}</span>
+              <span className="ml-2 text-white">{totalStarCount}</span>
             </div>
           )}
         </div>
         <p className="mt-2 text-base text-gray-400">This is a timeline of how the star count of {repoName} has grown till today.</p>
-        {lastUpdated && <p className="mt-3 text-gray-400 text-xs">Last updated on: {new Date(lastUpdated).toDateString()}</p>}
+        {!loadingStarHistory && (
+          <p className="mt-3 text-gray-400 text-xs">
+            {lastUpdated ? 
+              <>Last updated on: {new Date(lastUpdated).toDateString()}</>
+              : starHistory.length > 0 && <>
+                  <Loader size={18} additionalClassName="inline"/>
+                  <span className="transform translate-x-0.5 translate-y-0.5 inline-block">
+                    Loading data (
+                      {(starHistory[starHistory.length - 1].starNumber / totalStarCount * 100).toString().slice(0, 5)
+                    }% complete)
+                  </span>
+                </>
+            }
+          </p>
+        )}
       </div>
       <div className="flex-1 flex flex-col items-start">
         <div className={`w-full ${embed ? '' : 'pb-3 sm:pb-0 sm:pr-3'}`}>

--- a/icons/Loader.js
+++ b/icons/Loader.js
@@ -1,6 +1,6 @@
-const Loader = ({ size = 24 }) => (
+const Loader = ({ size = 24, additionalClassName=""}) => (
   <svg
-    className="animate-spin"
+    className={"animate-spin " + additionalClassName} 
     viewBox="0 0 24 24"
     width={size}
     height={size}

--- a/lib/RepoStarHistoryRetriever.js
+++ b/lib/RepoStarHistoryRetriever.js
@@ -10,23 +10,37 @@ export default class RepoStarHistoryRetriever {
     this.starHistory = []
     this.historyUpdateTime = null
     this.isLoading = true
+    this.totalStarCount = null
     this.subscriptions = new Map()
 
     this._loadStarHistory()
   }
 
   async _loadStarHistory(){
-    const {starHistory, historyUpdateTime} =
-      await getRepositoryStarHistory(this.supabase, this.starsTable, this.organization, this.repoName, this.githubAccessToken)
+    const {starHistory, historyUpdateTime, totalStarCount} =
+      await getRepositoryStarHistory(
+        this.supabase, this.starsTable, this.organization,
+        this.repoName, this.githubAccessToken, this._handleUpdate
+      )
     this.starHistory = starHistory
     this.historyUpdateTime = historyUpdateTime
     this.isLoading = false
+    this.totalStarCount = totalStarCount
+    this._notifyAllSubscribers()
+  }
+
+  // A function for handling intermediate results.
+  // This should be called once every 10 API calls.
+  _handleUpdate = (starHistory, totalStarCount) => {
+    this.starHistory = starHistory
+    this.isLoading = false
+    this.totalStarCount = totalStarCount
     this._notifyAllSubscribers()
   }
 
   _notifyAllSubscribers() {
     this.subscriptions.forEach((x) => 
-      x.callback(this.starHistory, this.historyUpdateTime, this.isLoading)
+      x.callback(this.starHistory, this.historyUpdateTime, this.isLoading, this.totalStarCount)
     )
   }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -196,7 +196,7 @@ export const retrieveStarHistory = async(organization, repoName, githubAccessTok
     stargazers = result.edges
 
     callCount += 1
-    if (callCount % 10 == 0) {
+    if (callCount % 4 == 0) {
       const recentHistory = starredAtArrayToHistory(starredAtArray)
       const combined = combineStarHistories(currentHistory, recentHistory)
       // Give the intermediate results to the callback function.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -119,50 +119,21 @@ const getGithubStarGql = async ({organization, repoName, cursor, githubAccessTok
   return(result.data.repository.stargazers)
 }
 
-// Output example:
+// Input example:
+// [["2020-04-21", "2020-04-22", "2020-04-23"],
+//  ["2020-04-29", "2020-04-29"]]
+//
+// Corresponding output example:
 // [{date: "2020-04-21", starNumber: 1},
 //  {date: "2020-04-22", starNumber: 2},
-//  {date: "2020-04-29", starNumber: 5},
-//  {date: "2020-04-30", starNumber: 10}]
-export const retrieveStarHistory = async(organization, repoName, githubAccessToken) => {
-  let starredAtArray = []
-  let cursor = null
-  // const startTime = new Date(); // for benchmarking
-  let result = await getGithubStarGql({organization, repoName, cursor, githubAccessToken})
-  let stargazers = result.edges
-  // stargazers format (note: oldest first):
-  // [{cursor: "Y3Vyc29yOnYyOpIAzg0_vtQ=", starredAt: "2020-05-29T19:27:49Z"},
-  //  {cursor: "Y3Vyc29yOnYyOpIAzg0_zE0=", starredAt: "2020-05-29T20:02:34Z"},
-  //  {cursor: "Y3Vyc29yOnYyOpIAzg0_zE0=", starredAt: "2020-05-30T20:02:34Z"}]
-
-  // Count the number of times the API has been called (for benchmarking)
-  // let callCount = 1
-
-  while (stargazers.length > 0) {
-    // Get the cursor of the newest event.
-    cursor = stargazers[stargazers.length - 1].cursor
-
-    // Use slice(0, 10) to get the date only (and not time).
-    starredAtArray.push(stargazers.map(x => x.starredAt.slice(0, 10)))
-    // Retrieve the starring events before the cursor.
-    result = await getGithubStarGql({organization, repoName, cursor, githubAccessToken})
-    stargazers = result.edges
-
-    // For benchmarking:
-    // callCount += 1
-    // if (callCount % 10 == 0) {
-    //   console.log(callCount)
-    //   const currentTime = new Date();
-    //   const elapsedSeconds = Math.round((currentTime - startTime) / 1000)
-    //   console.log(`Elapsed seconds: ${elapsedSeconds}`)
-    // }
-  }
-
-  starredAtArray = starredAtArray.flat()
+//  {date: "2020-04-23", starNumber: 3},
+//  {date: "2020-04-29", starNumber: 5}]
+const starredAtArrayToHistory = (starredAtArray) => {
+  const flatArray = starredAtArray.flat()
   let accumulativeCount = 0
   const starCountDateMap = {}
 
-  starredAtArray.forEach(dateString => {
+  flatArray.forEach(dateString => {
     accumulativeCount += 1
     const dates = Object.keys(starCountDateMap)
     if (dates.indexOf(dateString) === -1) {
@@ -178,8 +149,75 @@ export const retrieveStarHistory = async(organization, repoName, githubAccessTok
       starNumber: starCountDateMap[date]
     }
   })
-
   return starCountDateEvents
+}
+
+// Output example:
+// { starHistory:
+//  [{date: "2020-04-21", starNumber: 1},
+//  {date: "2020-04-22", starNumber: 2},
+//  {date: "2020-04-29", starNumber: 5},
+//  {date: "2020-04-30", starNumber: 10}],
+//   cursor: "Y3Vyc29yOnYyOpIAzgSA8pk=",
+//   totalStarCount: 333}
+//
+// NOTE: The final result will be currentHistory + recentHistory combined.
+// The recentHistory will be the history after the given cursor.
+// The currentHistory should be the history before the given cursor, inclusive.
+export const retrieveStarHistory = async(organization, repoName, githubAccessToken,
+                        currentHistory, cursor, supabase, starsTable, callback) => {
+  let starredAtArray = []
+  // const startTime = new Date(); // for benchmarking
+  let result = await getGithubStarGql({organization, repoName, cursor, githubAccessToken})
+  let stargazers = result.edges
+  const totalStarCount = result.totalCount
+  // stargazers format (note: oldest first):
+  // [{cursor: "Y3Vyc29yOnYyOpIAzg0_vtQ=", starredAt: "2020-05-29T19:27:49Z"},
+  //  {cursor: "Y3Vyc29yOnYyOpIAzg0_zE0=", starredAt: "2020-05-29T20:02:34Z"},
+  //  {cursor: "Y3Vyc29yOnYyOpIAzg0_zE0=", starredAt: "2020-05-30T20:02:34Z"}]
+
+  // Count the number of times the API has been called
+  let callCount = 1
+
+  while (stargazers.length > 0) {
+    // Get the cursor of the newest event.
+    cursor = stargazers[stargazers.length - 1].cursor
+
+    // Use slice(0, 10) to get the date only (and not time).
+    starredAtArray.push(stargazers.map(x => x.starredAt.slice(0, 10)))
+    // Retrieve the starring events before the cursor.
+    result = await getGithubStarGql({organization, repoName, cursor, githubAccessToken})
+    stargazers = result.edges
+
+    callCount += 1
+    if (callCount % 10 == 0) {
+      const recentHistory = starredAtArrayToHistory(starredAtArray)
+      const combined = combineStarHistories(currentHistory, recentHistory)
+      // Give the intermediate results to the callback function.
+      callback(combined, totalStarCount)
+
+      // Then, update the SB cache with the intermediate results.
+      await supabase
+        .from(starsTable)
+        .update({
+          star_history: combined,
+          updated_at: new Date().toISOString(),
+          is_complete: false,
+          cursor: cursor,
+          total_star_count: totalStarCount
+        })
+        .match({
+          organization: organization,
+          repository: repoName
+        })
+    //   The following is for benchmarking:
+    //   const currentTime = new Date();
+    //   const elapsedSeconds = Math.round((currentTime - startTime) / 1000)
+    //   console.log(`Elapsed seconds: ${elapsedSeconds}`)
+    }
+  }
+  const recentHistory = starredAtArrayToHistory(starredAtArray)
+  return {starHistory: combineStarHistories(currentHistory, recentHistory), cursor, totalStarCount}
 }
 
 export const retrieveStarHistoryLegacy = async(organization, repoName, githubAccessToken) => {
@@ -241,9 +279,16 @@ export const retrieveStarHistoryLegacy = async(organization, repoName, githubAcc
 //    {date: "2019-10-26", starNumber: 41},
 //    {date: "2019-10-27", starNumber: 46},
 //    {date: "2019-10-28", starNumber: 51}]
-//  historyUpdateTime: 1608888163296}
-export const getRepositoryStarHistory = async(supabase, starsTable, organization, repoName, githubAccessToken) => {
-  const { data, error } = await supabase
+//  historyUpdateTime: 1608888163296,
+//  totalStarCount: 333}
+//
+// NOTE: The callback function will be called once every 10 API calls.
+export const getRepositoryStarHistory = async(
+    supabase, starsTable, organization, repoName,
+    githubAccessToken, callback = () => {}) => {
+  
+  // First, check if we already have cached data in supabase.
+  let { data, error } = await supabase
     .from(starsTable)
     .select('*')
     .eq('organization', organization)
@@ -251,49 +296,75 @@ export const getRepositoryStarHistory = async(supabase, starsTable, organization
 
   if (error) {
     console.log(error)
-  } else if (data) {
-    if (data.length == 0) {
-      const starHistory = await renewStarHistory(supabase, starsTable, organization, repoName, githubAccessToken)
-      return {starHistory, historyUpdateTime: new Date().getTime()}
-    } else {
-      // Check if it's valid within 12 hours
-      const historyUpdateTime = new Date(data[0].updated_at).getTime()
-      const currentTime = new Date().getTime()
-      if (currentTime - historyUpdateTime <= (12*60*60*1000)) {
-        console.log(`Star history of ${repoName} still valid`)
-        return {starHistory: data[0].star_history, historyUpdateTime}
-      } else {
-        console.log(`Star history of ${repoName} invalid, refreshing`)
-        const starHistory = await renewStarHistory(supabase, starsTable, organization, repoName, githubAccessToken, true)
-        return {starHistory, historyUpdateTime: currentTime}
-      }
-    }
+    return
   }
-}
 
-export const renewStarHistory = async(supabase, starsTable, organization, repoName, githubAccessToken, update = false) => {
-  const starHistory = await retrieveStarHistory(organization, repoName, githubAccessToken)
-  if (update) {
-    await supabase
-      .from(starsTable)
-      .update({
-        star_history: starHistory,
-        updated_at: new Date().toISOString(),
-      })
-      .match({
-        organization: organization,
-        repository: repoName
-      })
-  } else {
-    await supabase
+  // If there's no data, insert an empty row.
+  if (data.length == 0) {
+    const result = await supabase
       .from(starsTable)
       .insert([
         {
           organization: organization,
           repository: repoName,
-          star_history: starHistory,
+          star_history: [],
+          updated_at: new Date().toISOString(),
+          is_complete: false,
+          cursor: null,
+          total_star_count: 0
         }
       ])
+    data = result.data
+    error = result.error
+
+    if (error) {
+      console.log(error)
+      return
+    }
   }
-  return starHistory
+
+  // Check if it's valid within 12 hours (TODO: change this to 1 hour?)
+  data = data[0]
+  const historyUpdateTime = new Date(data.updated_at).getTime()
+  let currentTime = new Date().getTime()
+  // If data is not complete, we need to finish populating it.
+  if (data.is_complete && currentTime - historyUpdateTime <= (12*60*60*1000)) {
+    console.log(`Star history of ${repoName} still valid`)
+    return {starHistory: data.star_history, historyUpdateTime, totalStarCount: data.total_star_count}
+  } else {
+    console.log(`Star history of ${repoName} invalid, refreshing`)
+    const {starHistory, totalStarCount} = await renewStarHistory(
+      supabase, starsTable, organization, repoName,
+      githubAccessToken, data.star_history, data.cursor, callback
+    )
+    currentTime = new Date().getTime()
+    return {starHistory, historyUpdateTime: currentTime, totalStarCount}
+  }
+}
+
+// Combine the newly retrieved history with currentHistory, and return it.
+// NOTE: the callback function will be called once every 10 API calls.
+// Output format: {starHistory, totalStarCount}
+export const renewStarHistory = async(supabase, starsTable, organization,
+                                repoName, githubAccessToken, currentHistory,
+                                cursor, callback) => 
+{
+  const {starHistory, cursor: updatedCursor, totalStarCount} =
+    await retrieveStarHistory(organization, repoName, githubAccessToken,
+                  currentHistory, cursor, supabase, starsTable, callback)
+  
+  await supabase
+    .from(starsTable)
+    .update({
+      star_history: starHistory,
+      updated_at: new Date().toISOString(),
+      is_complete: true,
+      cursor: updatedCursor,
+      total_star_count: totalStarCount
+    })
+    .match({
+      organization: organization,
+      repository: repoName
+    })
+  return {starHistory, totalStarCount}
 }

--- a/pages/[org]/[repo]/index.js
+++ b/pages/[org]/[repo]/index.js
@@ -19,6 +19,7 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
   const [lastUpdated, setLastUpdated] = useState(null)
   const [starHistory, setStarHistory] = useState([])
   const [loadingStarHistory, setLoadingStarHistory] = useState(false)
+  const [totalStarCount, setTotalStarCount] = useState(null)
 
   // An object of star history retrievers.
   // Example: {'supabase/supabase': RepoStarHistoryRetriever1, 'supabase/realtime': RepoStarHistoryRetriever2}
@@ -59,12 +60,15 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
     setStarHistory(starHistoryRetriever.starHistory)
     setLastUpdated(starHistoryRetriever.historyUpdateTime)
     setLoadingStarHistory(starHistoryRetriever.isLoading)
+    setTotalStarCount(starHistoryRetriever.totalStarCount)
 
     // Then, subscribe to any change in the star history retriever.
-    const { subscription } = starHistoryRetriever.onLoaded((starHistory, historyUpdateTime, isLoading) => {
+    const { subscription } = starHistoryRetriever.onLoaded(
+        (starHistory, historyUpdateTime, isLoading, totalStarCount) => {
       setStarHistory(starHistory)
       setLastUpdated(historyUpdateTime)
       setLoadingStarHistory(isLoading)
+      setTotalStarCount(totalStarCount)
     })
     
     return () => {
@@ -139,6 +143,7 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
               lastUpdated={lastUpdated}
               starHistory={starHistory}
               loadingStarHistory={loadingStarHistory}
+              totalStarCount={totalStarCount}
             />
             <IssueTracker
               repoName={repoName}

--- a/pages/[org]/[repo]/index.js
+++ b/pages/[org]/[repo]/index.js
@@ -12,9 +12,10 @@ import Check from '~/icons/Check'
 const issuesTable = process.env.NEXT_PUBLIC_SUPABASE_ISSUES_TABLE
 const starsTable = process.env.NEXT_PUBLIC_SUPABASE_STARS_TABLE
 
-const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => {
+const RepositoryStatistics = ({ githubAccessToken, supabase }) => {
 
   const router = useRouter()
+  const orgName = router.query.org
   const repoName = router.query.repo
 
   const [showModal, setShowModal] = useState(false)
@@ -40,7 +41,7 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
       const { data, error } = await supabase
         .from(issuesTable)
         .select('*')
-        .eq('organization', organization)
+        .eq('organization', orgName)
         .eq('repository', repoName)
       if (error) {
         console.error(error)
@@ -54,12 +55,12 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
   useEffect(() => {
     // First, check if a corresponding star history retriever exists.
     // If not, create a new one.
-    const starHistoryKey = `${organization}/${repoName}`
+    const starHistoryKey = `${orgName}/${repoName}`
     let starHistoryRetriever
     if (starHistoryKey in starHistoryRetrievers) {
       starHistoryRetriever = starHistoryRetrievers[starHistoryKey]
     } else {
-      starHistoryRetriever = new RepoStarHistoryRetriever(supabase, starsTable, organization, repoName, githubAccessToken)
+      starHistoryRetriever = new RepoStarHistoryRetriever(supabase, starsTable, orgName, repoName, githubAccessToken)
       const newRetrievers = Object.assign({}, starHistoryRetrievers)
       newRetrievers[starHistoryKey] = starHistoryRetriever
       setStarHistoryRetrievers(newRetrievers)
@@ -161,7 +162,7 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
           </div>
           <textarea
             ref={textAreaRef}
-            value={generateIframeCode(organization, repoName, iframeChartType)}
+            value={generateIframeCode(orgName, repoName, iframeChartType)}
             rows={4}
             readOnly
             className="w-full bg-gray-500 rounded-md p-3 font-mono text-sm text-white"
@@ -173,7 +174,7 @@ const RepositoryStatistics = ({ githubAccessToken, supabase, organization }) => 
       <div className="sm:mx-10 mb-12 sm:mb-20">
         <p className="text-gray-400 text-xs">REPOSITORY</p>
         <a
-          href={`https://github.com/${organization}/${repoName}`}
+          href={`https://github.com/${orgName}/${repoName}`}
           target="_blank"
           className="text-white text-3xl mt-1 group flex items-center"
         >

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -90,7 +90,7 @@ function MyApp({ Component, pageProps, router }) {
             {...pageProps}
             githubAccessToken={githubAccessToken}
             supabase={supabase}
-            organization={router.query.org}
+            organization={organization}
             repoNames={repos.map(repo => repo.name)}
             onUpdateFilterList={(repos) => setFilteredRepoNames(repos)}
           />


### PR DESCRIPTION
This PR enables incremental star retrieval!

Here's a quick demo:

https://user-images.githubusercontent.com/1811651/103342693-11fb2980-4a3f-11eb-8ca6-bea7dca2086e.mov

I think you'll notice a few things in the demo.

1. As soon as there are updates in retrieved data, it's shown as a chart.
2. It shows the percentage of data that's already been retrieved.
3. When you refresh the page and come back to the same repo, the data retrieval progress is not lost.

I achieved this by creating a new table called stars_incremental2, which has three additional columns - cursor, is_complete, and total_star_count.

cursor is the cursor of the last stargazer that we've seen.

is_complete is false when all of the data haven't been retrieved yet.

total_star_count shows the total star count of the repo even when all of the data haven't been retrieved yet.

With this, I'm able to store intermediate data retrieval results in this table so we don't have to get all the data every time.

If this seems okay, I would suggest renaming this new table to stars, and the current stars table to stars_legacy2 or something like that.

Also, I noticed that the UI changed a bit when I merged master. I hope I didn't break anything major when I resolved the merge conflicts. I really liked how it used to show the total number of stars - did it disappear because of one of @joshenlim's commits or because of how I resolved the merge conflicts? I wasn't sure.