### PR TITLE
Add 3 options of time to timeline chart and filter data accordingly

### DIFF
--- a/components/IssueTracker.js
+++ b/components/IssueTracker.js
@@ -89,14 +89,16 @@ const IssueTracker = ({
           </div>
           <div className="mt-5 flex items-center flex-wrap">
             <p className="text-white text-sm mr-2">View for:</p>
-            {options.map((option) => (
-              <Pill              
-                key={option.key}
-                label={option.label}
-                selected={option.key === issueType.key}
-                onSelectPill={() => setIssueType(option)}
-              />
-            ))}
+            <div className="space-x-2 flex items-center">
+              {options.map((option) => (
+                <Pill              
+                  key={option.key}
+                  label={option.label}
+                  selected={option.key === issueType.key}
+                  onSelectPill={() => setIssueType(option)}
+                />
+              ))}
+            </div>
           </div>
           <p className="mt-5 text-base text-gray-400">
             This is a timeline of how many {issueType.label.toLowerCase()} {repoName} has over time.

--- a/components/Pill.js
+++ b/components/Pill.js
@@ -2,16 +2,22 @@ const Pill = ({
   label = '',
   selected = false,
   onSelectPill = () => {},
-}) => (
-  <div
-    onClick={() => onSelectPill()}
-    className={`
-      border rounded-full text-xs text-gray-300 px-3 py-1 mr-2 cursor-pointer transition
-      ${selected ? 'text-brand-700 bg-gray-900' : 'hover:bg-gray-400 hover:text-white'}
-    `}
-  >
-    {label}
-  </div>
-)
+  withoutBorder = false,
+}) => {
+  const unselectedPillStyle = withoutBorder ? 'hover:text-white' : 'hover:bg-gray-400 hover:text-white'
+  const selectedPillStyle = withoutBorder ? 'text-brand-700' : 'text-brand-700 bg-gray-900'
+  return (
+    <div
+      onClick={() => onSelectPill()}
+      className={`
+        text-xs text-gray-300 px-3 py-1 cursor-pointer transition
+        ${withoutBorder ? 'border-r last:border-r-0 text-gray-400' : 'border rounded-full text-gray-300'}
+        ${selected ? selectedPillStyle : unselectedPillStyle}
+      `}
+    >
+      {label}
+    </div>
+  )
+}
 
 export default Pill

--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -55,7 +55,9 @@ const StarHistory = ({
             )}
           </div>
           <p className="mt-2 text-base text-gray-400">This is a timeline of how the star count of {repoName} has grown till today.</p>
-          {lastUpdated && <p className="mt-3 text-gray-400 text-xs">Last updated on: {new Date(lastUpdated).toDateString()}</p>}
+          {starHistory.length > 0  && lastUpdated && (
+            <p className="mt-3 text-gray-400 text-xs">Last updated on: {new Date(lastUpdated).toDateString()}</p>
+          )}
         </div>
       )}
       <div className="flex-1 flex flex-col items-start">

--- a/components/Toggle.js
+++ b/components/Toggle.js
@@ -24,11 +24,12 @@ const Toggle = ({
   label = '',
   isOn = false,
   size = 'xsm',
+  labelPosition = 'left',
   isDisabled = false,
 }) => {
   const toggleSizes = sizes[size]
   return (
-    <>
+    <div className={`flex items-center ${labelPosition === 'left' ? 'flex-row' : 'flex-row-reverse'}`}>
       <span
           role="checkbox"
           aria-checked="false"
@@ -46,8 +47,15 @@ const Toggle = ({
           } inline-block rounded-full shadow transform transition ease-in-out duration-200`}
           ></span>
       </span>
-      <span className='text-sm inline-block ml-2 transform translate-x-1 -translate-y-1 text-gray-400'>{label}</span>
-    </>
+      <span
+        className={`
+          text-sm inline-block ml-2 transform text-gray-400
+          ${labelPosition === 'left' ? 'translate-x-1' : '-translate-x-2'}
+        `}
+      >
+        {label}
+      </span>
+    </div>
   )
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -113,6 +113,7 @@ module.exports = {
       inset: ['group-hover'],
       stroke: ['dark'],
       height: ['hover'],
+      borderWidth: ['last'],
     },
   },
   plugins: [],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/repository.surf/issues/22

Added 3 options of time to filter the chart data by: today, past week and all time. Can be easily extended for other time options like past month too

![image](https://user-images.githubusercontent.com/19742402/103347658-91860880-4ad2-11eb-809b-69b97dba617c.png)
