### PR TITLE
Refresh star history data more frequently (every 12 hours -> every 1 hour)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -329,12 +329,12 @@ export const getRepositoryStarHistory = async(
     }
   }
 
-  // Check if it's valid within 12 hours (TODO: change this to 1 hour?)
+  // Check if it's valid within 1 hour
   data = data[0]
   const historyUpdateTime = new Date(data.updated_at).getTime()
   let currentTime = new Date().getTime()
   // If data is not complete, we need to finish populating it.
-  if (data.is_complete && currentTime - historyUpdateTime <= (12*60*60*1000)) {
+  if (data.is_complete && currentTime - historyUpdateTime <= (1*60*60*1000)) {
     console.log(`Star history of ${repoName} still valid`)
     return {starHistory: data.star_history, historyUpdateTime, totalStarCount: data.total_star_count}
   } else {


### PR DESCRIPTION
I think it's okay to refresh the data more frequently as we do incremental data retrieval for star histories now. So, if the data is more than 1 hour old, GitHub API will only be called once if there's no change.