### PR TITLE
refactor: Move up the starRetrievers into _app.js

### DIFF
--- a/lib/RepoStarHistoryRetriever.js
+++ b/lib/RepoStarHistoryRetriever.js
@@ -35,6 +35,8 @@ export default class RepoStarHistoryRetriever {
     this.starHistory = starHistory
     this.isLoading = false
     this.totalStarCount = totalStarCount
+    // NOTE: this.historyUpdateTime will still be null here
+    // assuming that the data retreival isn't complete yet.
     this._notifyAllSubscribers()
   }
 

--- a/pages/[org]/[repo]/index.js
+++ b/pages/[org]/[repo]/index.js
@@ -12,7 +12,7 @@ import Check from '~/icons/Check'
 const issuesTable = process.env.NEXT_PUBLIC_SUPABASE_ISSUES_TABLE
 const starsTable = process.env.NEXT_PUBLIC_SUPABASE_STARS_TABLE
 
-const RepositoryStatistics = ({ githubAccessToken, supabase }) => {
+const RepositoryStatistics = ({ githubAccessToken, supabase, starRetrievers, setStarRetrievers }) => {
 
   const router = useRouter()
   const orgName = router.query.org
@@ -30,10 +30,6 @@ const RepositoryStatistics = ({ githubAccessToken, supabase }) => {
   const [starHistory, setStarHistory] = useState([])
   const [loadingStarHistory, setLoadingStarHistory] = useState(false)
   const [totalStarCount, setTotalStarCount] = useState(null)
-
-  // An object of star history retrievers.
-  // Example: {'supabase/supabase': RepoStarHistoryRetriever1, 'supabase/realtime': RepoStarHistoryRetriever2}
-  const [starHistoryRetrievers, setStarHistoryRetrievers] = useState({})
 
   useEffect(() => {
     (async function retrieveRepositoryIssueCounts() {
@@ -57,13 +53,13 @@ const RepositoryStatistics = ({ githubAccessToken, supabase }) => {
     // If not, create a new one.
     const starHistoryKey = `${orgName}/${repoName}`
     let starHistoryRetriever
-    if (starHistoryKey in starHistoryRetrievers) {
-      starHistoryRetriever = starHistoryRetrievers[starHistoryKey]
+    if (starHistoryKey in starRetrievers) {
+      starHistoryRetriever = starRetrievers[starHistoryKey]
     } else {
       starHistoryRetriever = new RepoStarHistoryRetriever(supabase, starsTable, orgName, repoName, githubAccessToken)
-      const newRetrievers = Object.assign({}, starHistoryRetrievers)
+      const newRetrievers = Object.assign({}, starRetrievers)
       newRetrievers[starHistoryKey] = starHistoryRetriever
-      setStarHistoryRetrievers(newRetrievers)
+      setStarRetrievers(newRetrievers)
     }
 
     // In case the star history is already retrieved, load it on on this component.

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,6 +31,10 @@ function MyApp({ Component, pageProps, router }) {
   const [viewableRepos, setViewableRepos] = useState([])
   const [filteredRepoNames, setFilteredRepoNames] = useState([])
 
+  // An object of star history retrievers.
+  // Example: {'supabase/supabase': RepoStarHistoryRetriever1, 'supabase/realtime': RepoStarHistoryRetriever2}
+  const [starRetrievers, setStarRetrievers] = useState({})
+
   useEffect(() => {
     if (router.pathname !== '/' && router.query.org) {
       (async function retrieveGithub() {
@@ -93,6 +97,8 @@ function MyApp({ Component, pageProps, router }) {
             organization={organization}
             repoNames={repos.map(repo => repo.name)}
             onUpdateFilterList={(repos) => setFilteredRepoNames(repos)}
+            starRetrievers={starRetrievers}
+            setStarRetrievers={setStarRetrievers}
           />
         </Layout>
       )


### PR DESCRIPTION
Reminder: starRetrievers is an object of star history retrievers.
Example: {'supabase/supabase': RepoStarHistoryRetriever1, 'supabase/realtime': RepoStarHistoryRetriever2}

I moved it up from [org]/[repo]/index.js to _app.js. This way, it won't disappear even when you go to [org]/index.js. This is a necessary step for #11.

