### PR TITLE
feature: star history across org

### DIFF
--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -51,7 +51,7 @@ const StarHistory = ({
             {!loadingStarHistory && lastUpdated && starHistory.length > 0 && (
               <div className="flex items-center">
                 <Star />
-                <span className="ml-2 text-white">{starHistory[starHistory.length - 1].starNumber}</span>
+                <span className="ml-2 text-white">{totalStarCount}</span>
               </div>
             )}
           </div>

--- a/lib/RepoStarHistoryRetriever.js
+++ b/lib/RepoStarHistoryRetriever.js
@@ -59,7 +59,7 @@ export default class RepoStarHistoryRetriever {
       this.subscriptions.set(id, subscription)
       return { subscription, error: null }
     } catch (error) {
-      console.log(error)
+      console.error(error)
       return { subscription: null, error }
     }
   }

--- a/lib/StarHistoryAggregator.js
+++ b/lib/StarHistoryAggregator.js
@@ -95,7 +95,7 @@ export default class StarHistoryAggregator {
       this.subscriptions.set(id, subscription)
       return { subscription, error: null }
     } catch (error) {
-      console.log(error)
+      console.error(error)
       return { subscription: null, error }
     }
   }

--- a/lib/StarHistoryAggregator.js
+++ b/lib/StarHistoryAggregator.js
@@ -1,0 +1,102 @@
+import { combineStarHistories, uuid } from 'lib/helpers'
+import RepoStarHistoryRetriever from 'lib/RepoStarHistoryRetriever'
+
+// NOTE: starRetrievers is an object of star history retrievers.
+// Example: {'supabase/supabase': RepoStarHistoryRetriever1, 'supabase/realtime': RepoStarHistoryRetriever2}
+export default class StarHistoryAggregator {
+  constructor(supabase, starsTable, organization,
+              githubAccessToken, starRetrievers, repoNames) {
+    this.supabase = supabase
+    this.starsTable = starsTable
+    this.organization = organization
+    this.githubAccessToken = githubAccessToken
+    this.starRetrievers = starRetrievers
+    this.aggregatedStarHistory = []
+    this.aggregationLoadedTime = null
+    this.repoNames = repoNames
+    this.aggregationCount = 0
+    this.subscriptions = new Map()
+
+    this._aggregateStarHistories()
+  }
+
+  async _aggregateStarHistories(){
+    // For each repoName, create a repoStarHistoryRetriever and
+    // subscribe to its update.
+    this.repoNames.forEach(repoName => {
+      const starHistoryKey = `${this.organization}/${repoName}`
+      let starHistoryRetriever
+      if (starHistoryKey in this.starRetrievers) {
+        starHistoryRetriever = this.starRetrievers[starHistoryKey]
+      } else {
+        starHistoryRetriever = new RepoStarHistoryRetriever(this.supabase,
+            this.starsTable, this.organization, repoName, this.githubAccessToken)
+        this.starRetrievers[starHistoryKey] = starHistoryRetriever
+      }
+
+      // If historyUpdateTime is not null, then that means that the data
+      // retrieval has already finished.
+      if (starHistoryRetriever.historyUpdateTime) {
+        this.handleStarRetrievalCompleted(starHistoryRetriever.starHistory)
+      }
+
+      starHistoryRetriever.onLoaded(this._handleUpdate)
+    })
+  }
+
+  // A function for handling the updates from a starHistoryRetriever.
+  // This should be called every time one of the starHistoryRetrievers finishes loading.
+  _handleUpdate = (starHistory, historyUpdateTime, isLoading, totalStarCount) => {
+    // If historyUpdateTime is null, then that means that the data
+    // retrieval hasn't finished yet.
+    if (!historyUpdateTime) {
+      return
+    }
+    
+    this.handleStarRetrievalCompleted(starHistory)
+  }
+
+  // This function will be called each time we detect
+  // a star history retrieval process being completed.
+  handleStarRetrievalCompleted(starHistory) {
+    // Update the aggregated star history and increment count.
+    this.aggregatedStarHistory =
+      combineStarHistories(this.aggregatedStarHistory, starHistory)
+    this.aggregationCount += 1
+
+    // If all the aggregation has finished, notify the subscribers.
+    // Also update the aggregationLoadedTime to the oldest time
+    // one of the star histories has been loaded.
+    if (this.aggregationCount === this.repoNames.length) {
+      const updateTimes =
+        Object.entries(this.starRetrievers).map(x => x[1].historyUpdateTime)
+      this.aggregationLoadedTime = Math.min(...updateTimes)
+      
+      this._notifyAllSubscribers()
+    }
+  }
+
+  _notifyAllSubscribers() {
+    this.subscriptions.forEach((x) => 
+      x.callback(this.aggregatedStarHistory)
+    )
+  }
+
+  onAggregationFinished(callback){
+    try {
+      const id = uuid()
+      let self = this
+      const subscription = {
+        callback,
+        unsubscribe: () => {
+          self.subscriptions.delete(id)
+        },
+      }
+      this.subscriptions.set(id, subscription)
+      return { subscription, error: null }
+    } catch (error) {
+      console.log(error)
+      return { subscription: null, error }
+    }
+  }
+}

--- a/lib/StarHistoryAggregator.js
+++ b/lib/StarHistoryAggregator.js
@@ -78,7 +78,7 @@ export default class StarHistoryAggregator {
 
   _notifyAllSubscribers() {
     this.subscriptions.forEach((x) => 
-      x.callback(this.aggregatedStarHistory)
+      x.callback(this.aggregatedStarHistory, this.aggregationLoadedTime)
     )
   }
 

--- a/lib/fetchWrapper.js
+++ b/lib/fetchWrapper.js
@@ -13,7 +13,7 @@ export const fetchAllAndWait = async(urls, headers = {}, options = {}) => {
     )
     return response
   } catch (error) {
-    console.log('Error at fetchWrapper - fetchAllAndWait', error)
+    console.error('Error at fetchWrapper - fetchAllAndWait', error)
     throw error
   }
 }
@@ -32,7 +32,7 @@ export const fetchAndWait = async (url, headers = {}, options = {}) => {
     const body = await response.json()
     return body
   } catch (error) {
-    console.log('Error at fetchWrapper - fetchAndWait:', error)
+    console.error('Error at fetchWrapper - fetchAndWait:', error)
     throw error
   }
 }
@@ -52,7 +52,7 @@ export const postAndWait = async (url, data, headers = {}, options = {}) => {
     const body = await response.json()
     return body
   } catch (error) {
-    console.log('Error at fetchWrapper - postAndWait:', error)
+    console.error('Error at fetchWrapper - postAndWait:', error)
     throw error
   }
 }
@@ -71,7 +71,7 @@ export const patchAndWait = async (url, data, options = {}) => {
     const body = await response.json()
     return body
   } catch (error) {
-    console.log('Error at fetchWrapper - patchAndWait:', error)
+    console.error('Error at fetchWrapper - patchAndWait:', error)
     throw error
   }
 }
@@ -90,7 +90,7 @@ export const deleteAndWait = async (url, data, options = {}) => {
     const body = await response.json()
     return body
   } catch (error) {
-    console.log('Error at fetchWrapper - deleteAndWait:', error)
+    console.error('Error at fetchWrapper - deleteAndWait:', error)
     throw error
   }
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -125,6 +125,7 @@ const getGithubStarGql = async ({organization, repoName, cursor, githubAccessTok
   const variables = {organization, repoName, cursor}
 
   const result = await postToGitHubAPIv4(query, githubAccessToken, variables)
+
   return(result.data.repository.stargazers)
 }
 
@@ -304,7 +305,7 @@ export const getRepositoryStarHistory = async(
     .eq('repository', repoName)
 
   if (error || !data) {
-    console.log(error)
+    console.error(error)
     return
   }
 
@@ -327,7 +328,7 @@ export const getRepositoryStarHistory = async(
     error = result.error
 
     if (error) {
-      console.log(error)
+      console.error(error)
       return
     }
   }
@@ -338,10 +339,10 @@ export const getRepositoryStarHistory = async(
   let currentTime = new Date().getTime()
   // If data is not complete, we need to finish populating it.
   if (data.is_complete && currentTime - historyUpdateTime <= (1*60*60*1000)) {
-    console.log(`Star history of ${repoName} still valid`)
+    // console.log(`Star history of ${repoName} still valid`)
     return {starHistory: data.star_history, historyUpdateTime, totalStarCount: data.total_star_count}
   } else {
-    console.log(`Star history of ${repoName} invalid, refreshing`)
+    // console.log(`Star history of ${repoName} invalid, refreshing`)
     const {starHistory, totalStarCount} = await renewStarHistory(
       supabase, starsTable, organization, repoName,
       githubAccessToken, data.star_history, data.cursor, callback

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -90,6 +90,16 @@ export const combineStarHistories = (h1, h2) => {
   return output.slice(0, output.length - 1).reverse()
 }
 
+const postToGitHubAPIv4 = async(query, githubAccessToken, variables={}) => {
+  const url = 'https://api.github.com/graphql'
+  const headers = {
+    'Authorization': `bearer ${githubAccessToken}` 
+  }
+  const body = {query, variables}
+  const result = await postAndWait(url, body, headers)
+  return result
+}
+
 // Original source: https://github.com/ansonyao/monthlyStarHistory/blob/master/frontend/src/Service/index.js
 // License: https://github.com/ansonyao/monthlyStarHistory/blob/master/LICENSE
 const getGithubStarGql = async ({organization, repoName, cursor, githubAccessToken}) => {
@@ -112,16 +122,9 @@ const getGithubStarGql = async ({organization, repoName, cursor, githubAccessTok
         }
     }
   `
-  
-  const url = 'https://api.github.com/graphql'
-  const headers = {
-    'Authorization': `bearer ${githubAccessToken}` 
-  }
-  const body =  {
-    query,
-    variables: {organization, repoName, cursor},
-  }
-  const result = await postAndWait(url, body, headers)
+  const variables = {organization, repoName, cursor}
+
+  const result = await postToGitHubAPIv4(query, githubAccessToken, variables)
   return(result.data.repository.stargazers)
 }
 

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -9,8 +9,14 @@ import TimelineChart from 'components/TimelineChart'
 const issuesTable = process.env.NEXT_PUBLIC_SUPABASE_ISSUES_TABLE
 const starsTable = process.env.NEXT_PUBLIC_SUPABASE_STARS_TABLE
 
-const OrganizationOverview = ({ supabase, organization, repoNames,
-              starRetrievers, setStarRetrievers, githubAccessToken }) => {
+const OrganizationOverview = ({
+  loaded,
+  supabase,
+  organization,
+  repoNames,
+  starRetrievers,
+  githubAccessToken
+}) => {
   const [issueCounts, setIssueCounts] = useState([])
   const [aggregatedStarHistory, setAggregatedStarHistory] = useState([])
   const [aggregationLoading, setAggregationLoading] = useState(true)
@@ -51,7 +57,7 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
 
   useEffect(() => {
     // If orgName is not loaded yet, do nothing.
-    if (!orgName) {
+    if (!loaded || !orgName || repoNames.length === 0) {
       return
     }
     const aggregator = new StarHistoryAggregator(supabase, starsTable,
@@ -73,7 +79,7 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
     return () => {
       subscription.unsubscribe()
     }
-  }, [orgName])
+  }, [repoNames])
 
   const renderOrganizationIssuesTimeline = () => {
     if (issueCounts.length > 0) {

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -117,14 +117,16 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
           }
         </div>
       </div>
-      <StarHistory
-        repoName={'all repos (up to 100) in this organization'}
-        lastUpdated={aggregationLoadedTime}
-        starHistory={aggregatedStarHistory}
-        totalStarCount={totalStarCount}
-        loadingStarHistory={aggregationLoading}
-        onOpenModal={false}
-      />
+      <div className="mt-16">
+        <StarHistory
+          repoName={'all repos (up to 100) in this organization'}
+          lastUpdated={aggregationLoadedTime}
+          starHistory={aggregatedStarHistory}
+          totalStarCount={totalStarCount}
+          loadingStarHistory={aggregationLoading}
+          onOpenModal={false}
+        />
+      </div>
     </>
   )
 }

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -49,6 +49,10 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
   }, [organization])
 
   useEffect(() => {
+    // If orgName is not loaded yet, do nothing.
+    if (!orgName) {
+      return
+    }
     const aggregator = new StarHistoryAggregator(supabase, starsTable,
       orgName, githubAccessToken, starRetrievers, repoNames)
     setAggregatedStarHistory(aggregator.aggregatedStarHistory)
@@ -65,7 +69,7 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
     return () => {
       subscription.unsubscribe()
     }
-  }, [organization])
+  }, [orgName])
 
   const renderOrganizationIssuesTimeline = () => {
     if (issueCounts.length > 0) {

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -15,6 +15,7 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
   const [aggregatedStarHistory, setAggregatedStarHistory] = useState([])
   const [aggregationLoading, setAggregationLoading] = useState(true)
   const [aggregationLoadedTime, setAggregationLoadedTime] = useState(null)
+  const [totalStarCount, setTotalStarCount] = useState(null)
   const [loadingIssueCounts, setLoadingIssueCounts] = useState(false)
   const orgName = organization.login
   const formattedOrgName = organization.name
@@ -55,14 +56,17 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
     }
     const aggregator = new StarHistoryAggregator(supabase, starsTable,
       orgName, githubAccessToken, starRetrievers, repoNames)
-    setAggregatedStarHistory(aggregator.aggregatedStarHistory)
+    const starHistory = aggregator.aggregatedStarHistory
+    setAggregatedStarHistory(starHistory)
     setAggregationLoadedTime(aggregator.aggregationLoadedTime)
     if(aggregator.aggregatedStarHistory.length > 0){
+      setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
       setAggregationLoading(false)
     }
 
-    const { subscription } = aggregator.onAggregationFinished((aggregatedStarHistory, aggregationLoadedTime) => {
-      setAggregatedStarHistory(aggregatedStarHistory)
+    const { subscription } = aggregator.onAggregationFinished((starHistory, aggregationLoadedTime) => {
+      setAggregatedStarHistory(starHistory)
+      setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
       setAggregationLoadedTime(aggregationLoadedTime)
       setAggregationLoading(false)
     })
@@ -117,6 +121,7 @@ const OrganizationOverview = ({ supabase, organization, repoNames,
         repoName={'all repos (up to 100) in this organization'}
         lastUpdated={aggregationLoadedTime}
         starHistory={aggregatedStarHistory}
+        totalStarCount={totalStarCount}
         loadingStarHistory={aggregationLoading}
         onOpenModal={false}
       />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,7 +37,11 @@ function MyApp({ Component, pageProps, router }) {
 
   useEffect(() => {
     if (router.pathname !== '/' && router.query.org) {
-      (async function retrieveGithub() {
+      (async function retrieveOrganizationProfile() {
+        setLoaded(false)
+        const org = await fetchAndWait(`https://api.github.com/orgs/${router.query.org}`)
+        setOrganization(org)
+
         const repos = await fetchAndWait(
           `https://api.github.com/orgs/${router.query.org}/repos?per_page=100`,
           { 'Authorization': `token ${githubAccessToken}` }
@@ -45,21 +49,12 @@ function MyApp({ Component, pageProps, router }) {
         setRepos(repos.sort((a, b) => a.stargazers_count > b.stargazers_count ? -1 : 1))
         setLoaded(true)
       })()
-  
+
       const userPreferences = JSON.parse(localStorage.getItem(`repoSurf_${router.query.org}`))
       if (userPreferences && userPreferences.repoFilter) {
         const formattedFilterList = userPreferences.repoFilter.split(',').map(repo => repo.replace(/^[ ]+/g, ""))
         setFilteredRepoNames(formattedFilterList)      
       }
-    }
-  }, [router.query.org])
-
-  useEffect(() => {
-    if (router.pathname !== '/' && router.query.org) {
-      (async function retrieveOrganizationProfile() {
-        const org = await fetchAndWait(`https://api.github.com/orgs/${router.query.org}`)
-        setOrganization(org)
-      })()
     }
   }, [router.query.org])
 
@@ -92,6 +87,7 @@ function MyApp({ Component, pageProps, router }) {
         >
           <Component
             {...pageProps}
+            loaded={loaded}
             githubAccessToken={githubAccessToken}
             supabase={supabase}
             organization={organization}


### PR DESCRIPTION
- Show a star chart for a whole organization (#11). For now, it only works with organizations with <= 100 repos. I'll make an issue to adjust this problem.
- Refactor the function that POSTs to GitHub API v4
- Show totalStarCount when loading a star history