### PR TITLE
fix: whole-org star history showing up when it shouldn't

### DIFF
--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -65,7 +65,9 @@ const OrganizationOverview = ({
     const starHistory = aggregator.aggregatedStarHistory
     setAggregatedStarHistory(starHistory)
     setAggregationLoadedTime(aggregator.aggregationLoadedTime)
-    if(aggregator.aggregatedStarHistory.length > 0){
+    // If aggregationLoadedTime is not null, then that means that
+    // the aggregation has finished.
+    if(aggregator.aggregationLoadedTime){
       setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
       setAggregationLoading(false)
     }


### PR DESCRIPTION
This fixes the following problem described by @joshenlim at #42:

> While the organization's star history is loading, if we go to a repository page and the repository's star history is still loading, then go back to the organization overview page, the star history on the organization page will show a chart (that's incomplete cause not all the data is pulled in yet) and with a Loading 100% message