### PR TITLE
feature: show org star history aggregation progress

### DIFF
--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -11,6 +11,7 @@ const StarHistory = ({
   lastUpdated,
   starHistory,
   loadingStarHistory,
+  loadingMessage = null,
   totalStarCount,
   onOpenModal
 }) => {
@@ -89,7 +90,9 @@ const StarHistory = ({
             ? (
               <div className="py-24 lg:py-32 text-white w-full flex flex-col items-center justify-center">
                 <Loader />
-                <p className="text-xs mt-3 leading-5 text-center">Retrieving repository star history</p>
+                <p className="text-xs mt-3 leading-5 text-center">
+                  {loadingMessage || "Retrieving repository star history"}
+                </p>
               </div>
             )
             : (

--- a/lib/StarHistoryAggregator.js
+++ b/lib/StarHistoryAggregator.js
@@ -64,25 +64,24 @@ export default class StarHistoryAggregator {
       combineStarHistories(this.aggregatedStarHistory, starHistory)
     this.aggregationCount += 1
 
-    // If all the aggregation has finished, notify the subscribers.
-    // Also update the aggregationLoadedTime to the oldest time
-    // one of the star histories has been loaded.
+    // If all the aggregation has finished, update the aggregationLoadedTime
+    // to the oldest time one of the star histories has been loaded.
     if (this.aggregationCount === this.repoNames.length) {
       const updateTimes =
         Object.entries(this.starRetrievers).map(x => x[1].historyUpdateTime)
       this.aggregationLoadedTime = Math.min(...updateTimes)
-      
-      this._notifyAllSubscribers()
     }
+
+    this._notifyAllSubscribers()
   }
 
   _notifyAllSubscribers() {
     this.subscriptions.forEach((x) => 
-      x.callback(this.aggregatedStarHistory, this.aggregationLoadedTime)
+      x.callback(this.aggregatedStarHistory, this.aggregationLoadedTime, this.aggregationCount)
     )
   }
 
-  onAggregationFinished(callback){
+  onAggregationUpdated(callback){
     try {
       const id = uuid()
       let self = this

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -21,6 +21,7 @@ const OrganizationOverview = ({
   const [aggregatedStarHistory, setAggregatedStarHistory] = useState([])
   const [aggregationLoading, setAggregationLoading] = useState(true)
   const [aggregationLoadedTime, setAggregationLoadedTime] = useState(null)
+  const [aggregationCount, setAggregationCount] = useState(0)
   const [totalStarCount, setTotalStarCount] = useState(null)
   const [loadingIssueCounts, setLoadingIssueCounts] = useState(false)
   const orgName = organization.login
@@ -65,6 +66,7 @@ const OrganizationOverview = ({
     const starHistory = aggregator.aggregatedStarHistory
     setAggregatedStarHistory(starHistory)
     setAggregationLoadedTime(aggregator.aggregationLoadedTime)
+    setAggregationCount(aggregator.aggregationCount)
     // If aggregationLoadedTime is not null, then that means that
     // the aggregation has finished.
     if(aggregator.aggregationLoadedTime){
@@ -72,11 +74,15 @@ const OrganizationOverview = ({
       setAggregationLoading(false)
     }
 
-    const { subscription } = aggregator.onAggregationFinished((starHistory, aggregationLoadedTime) => {
+    const { subscription } = aggregator.onAggregationUpdated(
+        (starHistory, aggregationLoadedTime, aggregationCount) => {
       setAggregatedStarHistory(starHistory)
-      setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
       setAggregationLoadedTime(aggregationLoadedTime)
-      setAggregationLoading(false)
+      setAggregationCount(aggregationCount)
+      if(aggregator.aggregationLoadedTime){
+        setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
+        setAggregationLoading(false)
+      }
     })
     return () => {
       subscription.unsubscribe()
@@ -115,6 +121,7 @@ const OrganizationOverview = ({
         starHistory={aggregatedStarHistory}
         totalStarCount={totalStarCount}
         loadingStarHistory={aggregationLoading}
+        loadingMessage={`Preparing star history... ${aggregationCount} out of ${repoNames.length} repos loaded.`}
         enableSharing={false}
       />
       <div className="pb-5 sm:px-10 sm:pb-10">


### PR DESCRIPTION
## What is the new behavior?

It shows the selected organization's star history aggregation progress. This addresses #42. It's based on #45.

Demo video:

https://user-images.githubusercontent.com/1811651/103449155-fbc8b580-4c58-11eb-8164-c93b47ab92b8.mov