### PR TITLE
fix: star history loading problem

### DIFF
--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -103,7 +103,7 @@ const StarHistory = ({
                 </div>
               )}
             </div>
-            {!loadingStarHistory && lastUpdated && starHistory.length > 0 && (
+            {!loadingStarHistory && lastUpdated !== null && starHistory.length > 0 && (
               <div className="flex items-center">
                 <Icon type="Star" size={20} strokeWidth={2} className="text-white" />
                 <span className="ml-2 text-white">{totalStarCount}</span>
@@ -111,7 +111,7 @@ const StarHistory = ({
             )}
           </div>
           <p className="mt-2 text-base text-gray-400">This is a timeline of how the star count of {repoName} has grown till today.</p>
-          {!loadingStarHistory && !lastUpdated && starHistory.length > 0 && (
+          {!loadingStarHistory && lastUpdated === null && starHistory.length > 0 && (
             <div className="mt-5 flex item-center text-xs text-gray-400">
               <Icon type="Loader" className="animate-spin text-white inline" size={18} strokeWidth={2} />
               <span className="ml-2 transform translate-x-0.5 translate-y-0.5 inline-block">

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -67,7 +67,7 @@ const OrganizationOverview = ({
     setAggregationCount(aggregator.aggregationCount)
     // If aggregationLoadedTime is not null, then that means that
     // the aggregation has finished.
-    if(aggregator.aggregationLoadedTime && starHistory.length > 0){
+    if(aggregator.aggregationLoadedTime !== null && starHistory.length > 0){
       setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
       setAggregationLoading(false)
     }
@@ -77,7 +77,7 @@ const OrganizationOverview = ({
       setAggregatedStarHistory(starHistory)
       setAggregationLoadedTime(aggregationLoadedTime)
       setAggregationCount(aggregationCount)
-      if(aggregator.aggregationLoadedTime){
+      if(aggregationLoadedTime !== null){
         setTotalStarCount(starHistory[starHistory.length - 1].starNumber)
         setAggregationLoading(false)
       }


### PR DESCRIPTION
This fixes the first part of #78. We still modify it so that when a single repo is selected, it will start showing partial data as soon as it's available.