### PR TITLE
fix: the problem where a message like "0 out of 0 repos loading" shows up

### DIFF
--- a/components/StarHistory.js
+++ b/components/StarHistory.js
@@ -16,6 +16,7 @@ const StarHistory = ({
   loadingMessage = null,
   totalStarCount,
   noStarHistory = false,
+  noReposSelected,
   onOpenShare = () => {},
 }) => {
 
@@ -127,6 +128,10 @@ const StarHistory = ({
         <div className={`w-full ${embed ? '' : 'pb-3 sm:pb-0 sm:pr-3'}`}>
           {loadingStarHistory
             ? (
+              noReposSelected ?
+              <div className="py-24 lg:py-36 flex items-center justify-center text-gray-400">
+                Select a repository first to view its star history
+              </div> :
               <div className="py-24 lg:py-32 text-white w-full flex flex-col items-center justify-center">
                 <Icon type="Loader" className="animate-spin text-white" size={24} strokeWidth={2} />
                 <p className="text-xs mt-3 leading-5 text-center">

--- a/pages/[org]/index.js
+++ b/pages/[org]/index.js
@@ -158,6 +158,7 @@ const OrganizationOverview = ({
         loadingMessage={`Preparing star history... ${aggregationCount} out of ${repoNames.length} repos loaded.`}
         enableSharing={false}
         noStarHistory={repoNames.length > 0 && aggregatedStarHistory.length === 0}
+        noReposSelected={repoNames.length === 0}
       />
       <IssueTracker
         issuesRef={references.issues}


### PR DESCRIPTION
Fixes the last part of #78 and closes #78:

> Another related issue I found: when you select a repo that's loading and deselect it, it shows something like "0 out of 0 repos loading..." with a loader.

This turned out to be more tricky than I thought. The problem seems to be that when deselecting all repos, two things are supposed to happen.

1. starHistory becomes empty
2. renderTimelineChart() is called

Ideally, 1 should happen before 2, but in reality, 2 happens before 1. For some reason, after 2 happens and then 1, 2 doesn't happen right after that.

So, as a (temporary) fix, I passed down noReposSelected to StarHistory, which bypasses this race condition. With this new prop, even if 2 is called without 1 being called first, StarHistory will know that no repos are selected - so it's able to show the correct component.